### PR TITLE
Minor improvements (add tests, convert warning to error)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -225,8 +225,8 @@ normalise_comp <- function(data, comp_labels){
 #' @inheritParams process_zeroes
 rescale_comp <- function(data, comp_labels, comp_sum){
   output <- data
-  if (!isTRUE(all.equal(apply(output[, comp_labels], 1, sum), rep(1, times = nrow(output)), tolerance = 0.01, check.attributes = FALSE))){
-    warning("Rescaling was applied even though not all rows summed to 1. This may be because this function is being applied at the wrong point. It may also occur if there are missing values in the compositional columns. Repeat after removing any missing or non-numeric compositional values.")
+  if (!isTRUE(all.equal(apply(output[, comp_labels], 1, sum), rep(1, times = nrow(output)), tolerance = 0.001, check.attributes = FALSE))){
+    stop("Rescaling was applied even though not all rows summed to 1. This may be because the function rescale_comp is being applied at the wrong point. It may also occur if there are missing values in the compositional columns. Repeat after removing any missing or non-numeric compositional values. If the error persists, this could be a bug - please contact R-Walmsley (rosemary.walmsley@gtc.ox.ac.uk).")
     }
   output[, comp_labels] <- output[, comp_labels]*comp_sum
   return(output)

--- a/tests/testthat/test-predicts-0-at-mean.R
+++ b/tests/testthat/test-predicts-0-at-mean.R
@@ -7,6 +7,22 @@ m <- comp_model(
   comp_labels = comp_labels,
   rounded_zeroes = TRUE
 )
+m2 <- comp_model(
+  type = "logistic",
+  data = simdata,
+  outcome = "disease",
+  covariates = c("agegroup", "sex"),
+  comp_labels = comp_labels,
+  rounded_zeroes = TRUE
+)
+m3 <- comp_model(
+  type = "cox",
+  data = simdata,
+  outcome = survival::Surv(simdata$follow_up_time, simdata$event),
+  covariates = c("agegroup", "sex"),
+  comp_labels = comp_labels,
+  rounded_zeroes = TRUE
+)
 nd <- comp_mean(
   data = simdata,
   rounded_zeroes = TRUE,
@@ -17,4 +33,41 @@ test_that("prediction at the comp mean is 0", {
                predict_fit_and_ci(
                  model = m,
                  new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "fit"])
+})
+
+test_that("prediction at the comp mean is 0", {
+  expect_equal(0,
+               as.numeric(predict_fit_and_ci(
+                 model = m,
+                 new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "upper_CI"]))
+})
+
+
+test_that("prediction at the comp mean is 1 - logistic", {
+  expect_equal(1,
+               predict_fit_and_ci(
+                 model = m2,
+                 new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "fit"])
+})
+
+
+test_that("prediction at the comp mean is 1 - logistic", {
+  expect_equal(1,
+               as.numeric(predict_fit_and_ci(
+                 model = m2,
+                 new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "lower_CI"]))
+})
+
+test_that("prediction at the comp mean is 1 - cox", {
+  expect_equal(1,
+               predict_fit_and_ci(
+                 model = m3,
+                 new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "fit"])
+})
+
+test_that("prediction at the comp mean is 1 - cox", {
+  expect_equal(1,
+               as.numeric(predict_fit_and_ci(
+                 model = m3,
+                 new_data = nd, comp_labels = comp_labels,terms = TRUE)[1, "upper_CI"]))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -74,8 +74,8 @@ test_that("rescaling normalised composition can get back to input", {
 })
 
 
-test_that("warning if normalise data not on a single scale", {
-  expect_warning(rescale_comp(nc_messed_up, comp_labels, 24))
+test_that("warning if normalised data not on a single scale", {
+  expect_error(rescale_comp(nc_messed_up, comp_labels, 24))
 })
 
 test_that("rescale_det_limit throws error if no clear scale", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -74,7 +74,7 @@ test_that("rescaling normalised composition can get back to input", {
 })
 
 
-test_that("warning if normalised data not on a single scale", {
+test_that("error if normalised data not on a single scale", {
   expect_error(rescale_comp(nc_messed_up, comp_labels, 24))
 })
 


### PR DESCRIPTION
This adds two minor improvements: 
- additional tests at compositional mean
- converting a warning to an error and increasing demand to catch possible bugs