### PR TITLE
remove test using R devel

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -25,8 +25,7 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-
+     
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}


### PR DESCRIPTION
R devel version is fast-changing, can be slow to run and is probably unnecessary from CI point of view.