### PR TITLE
make plot labels more robust  by using same aes as plot spec

### DIFF
--- a/R/simplex_plotting.R
+++ b/R/simplex_plotting.R
@@ -68,13 +68,13 @@ plot_density_ternary <-
             colour = "black"
           ) +
           theme +
-          ggtern::theme_showarrows() +
-          ggtern::Tlab(label = "",
-                       labelarrow = paste(name2, "(%)", "\n")) +
-          ggtern::Rlab(label = "",
-                       labelarrow = paste("\n", name3, "(%)")) +
-          ggtern::Llab(label = "",
-                       labelarrow = paste(name1, "(%)", "\n"))
+        ggtern::theme_showarrows() +
+        ggplot2::labs( x       = "",
+                xarrow  = paste(name1, "(%)", "\n"),
+                y       = "",
+                yarrow  = paste(name2, "(%)", "\n"),
+                z       = "",
+                 zarrow  =  paste("\n", name3, "(%)"))
       }
       else{
         plot <-
@@ -104,12 +104,12 @@ plot_density_ternary <-
         plot <-
           plot + theme +
           ggtern::theme_showarrows() +
-          ggtern::Tlab(label = "",
-                       labelarrow = paste(name2, "(%)", "\n")) +
-          ggtern::Rlab(label = "",
-                       labelarrow = paste("\n", name3, "(%)")) +
-          ggtern::Llab(label = "",
-                       labelarrow = paste(name1, "(%)", "\n"))
+          ggplot2::labs( x       = "",
+                         xarrow  = paste(name1, "(%)", "\n"),
+                         y       = "",
+                         yarrow  = paste(name2, "(%)", "\n"),
+                         z       = "",
+                         zarrow  =  paste("\n", name3, "(%)"))
       }
 
     }
@@ -126,12 +126,12 @@ plot_density_ternary <-
           ) +
           theme +
           ggtern::theme_showarrows() +
-          ggtern::Tlab(label = "",
-                       labelarrow = paste(name2, "(%)", "\n")) +
-          ggtern::Rlab(label = "",
-                       labelarrow = paste("\n", name3, "(%)")) +
-          ggtern::Llab(label = "",
-                       labelarrow = paste(name1, "(%)", "\n")) +
+          ggplot2::labs( x       = "",
+                         xarrow  = paste(name1, "(%)", "\n"),
+                         y       = "",
+                         yarrow  = paste(name2, "(%)", "\n"),
+                         z       = "",
+                         zarrow  =  paste("\n", name3, "(%)")) +
           ggtern::geom_crosshair_tern(
             data = mark_points,
             mapping = ggplot2::aes_(x = mark_points[, name1], y = mark_points[,  name2], z = mark_points[, name3])
@@ -173,12 +173,12 @@ plot_density_ternary <-
               color = mark_points[, groups]
             )
           ) + ggtern::theme_showarrows() +
-          ggtern::Tlab(label = "",
-                       labelarrow = paste(name2, "(%)", "\n")) +
-          ggtern::Rlab(label = "",
-                       labelarrow = paste("\n", name3, "(%)")) +
-          ggtern::Llab(label = "",
-                       labelarrow = paste(name1, "(%)", "\n"))
+          ggplot2::labs( x       = "",
+                         xarrow  = paste(name1, "(%)", "\n"),
+                         y       = "",
+                         yarrow  = paste(name2, "(%)", "\n"),
+                         z       = "",
+                         zarrow  =  paste("\n", name3, "(%)"))
 
       }
 


### PR DESCRIPTION
Previously plot arrow labels used Tlab, Rlab and Llab for specification.

Based on the default options when loading the  version of `ggtern` I was using, they seem to have been behaving correctly however this isn't very robust as it relies on consistent translation between x, y, z and T, R, L. This is determined by a global option, so: could be changed by users; may vary between `ggtern` versions. Note also that this current default behaviour doesn't match some of the documentation suggesting it has changed between versions. 

Therefore this change specifies them in terms of x, y, z i.e. directly matching the aesthetics used for the plot.