### PR TITLE
Add some tests

### DIFF
--- a/tests/testthat/test-predict_fit_and_ci.R
+++ b/tests/testthat/test-predict_fit_and_ci.R
@@ -343,7 +343,7 @@ t_p1_sed <- predict_fit_and_ci(m5, md, comp_labels = comp_labels, part_1 = "sede
 t_p1_sleep <- predict_fit_and_ci(m6, md, comp_labels = comp_labels, part_1 = "sleep")
 
 test_that("order of ilr parts doesn't matter for global compositional predictions", {
-  expect_equal(t_p1_sed$fit,t_p1_sleep $fit)
+  expect_equal(t_p1_sed$fit,t_p1_sleep$fit)
 })
 
 test_that("order of ilr parts doesn't matter - CI ", {

--- a/tests/testthat/test-predict_fit_and_ci.R
+++ b/tests/testthat/test-predict_fit_and_ci.R
@@ -215,7 +215,15 @@ dcs <- deltacomp::predict_delta_comps(
   comparisons = "one-v-one",
   alpha = 0.05
 )
-
+dcs2 <- deltacomp::predict_delta_comps(
+  dataf = fat_data,
+  y = "z_bmi",
+  comps = comp_labels,
+  covars = c("shuttles_20m", "height"),
+  deltas = seq(-10, 10, by = 5) / (24 * 60),
+  comparisons = "prop-realloc",
+  alpha = 0.05
+)
 epic_linear <- comp_model(type = "linear", data = fat_data, rounded_zeroes = FALSE, outcome = "z_bmi",comp_labels = comp_labels,covariates = c("shuttles_20m", "height"))
 newdata <- data.frame(matrix(ncol = 0, nrow = 2) )
 newdata$sleep <- c(comp_mean(fat_data, comp_labels = comp_labels)$sleep - (-1/(24*6)), comp_mean(fat_data, comp_labels = comp_labels)$sleep)
@@ -223,6 +231,8 @@ newdata$sed <-  c(comp_mean(fat_data, comp_labels = comp_labels)$sed + (-1/(24*6
 newdata$lpa <- c(comp_mean(fat_data, comp_labels = comp_labels)$lpa, comp_mean(fat_data, comp_labels = comp_labels)$lpa + 1/(24*6))
 newdata$mvpa <- c(comp_mean(fat_data, comp_labels = comp_labels)$mvpa, comp_mean(fat_data, comp_labels = comp_labels)$mvpa)
 
+cd <- as.data.frame(comp_mean(fat_data, comp_labels = comp_labels))
+newdata[3, comp_labels] <- change_composition(cd, main_change = -1/(24*6), main_part = "sed", comp_labels = comp_labels )
 
 ps <- predict_fit_and_ci(epic_linear, newdata, comp_labels = comp_labels)
 
@@ -235,8 +245,15 @@ test_that("equals lower ci from deltacomp package", {
 test_that("equals upper ci from deltacomp package", {
   expect_equal(ps$upper_CI[1:2], dcs$ci_up[1:2])
 })
-
-
+test_that("equals results from deltacomp package", {
+  expect_equal(ps$fit[3], dcs2$delta_pred[1])
+})
+test_that("equals lower ci from deltacomp package", {
+  expect_equal(ps$lower_CI[3], dcs2$ci_lo[1])
+})
+test_that("equals upper ci from deltacomp package", {
+  expect_equal(ps$upper_CI[3], dcs2$ci_up[1])
+})
 
 #=====
 

--- a/tests/testthat/test-predict_fit_and_ci.R
+++ b/tests/testthat/test-predict_fit_and_ci.R
@@ -297,3 +297,42 @@ test_that("when covariates, two CI types for Cox are different", {
 test_that("when covariates, two CI types for Cox are different", {
   expect_false(isTRUE(all.equal(as.vector((log(t_yes_cov$upper_CI) - log(t_yes_cov$fit))/1.96), as.vector(t_no_cov$se.fit),  tolerance = 0.00001 )))
 })
+
+#===================
+# Look at invariance properties
+m5 <- comp_model(
+  type = "cox",
+  data = epicoda::simdata,
+  follow_up_time = "follow_up_time",
+  event = "event",
+  comp_labels = comp_labels,
+  covariates = c("agegroup"),
+  part_1 = "sedentary",
+  rounded_zeroes = FALSE
+)
+
+m6 <- comp_model(
+  type = "cox",
+  data = epicoda::simdata,
+  follow_up_time = "follow_up_time",
+  event = "event",
+  comp_labels = comp_labels,
+  covariates = c("agegroup"),
+  part_1 = "sleep",
+  rounded_zeroes = FALSE
+)
+
+t_p1_sed <- predict_fit_and_ci(m5, md, comp_labels = comp_labels, part_1 = "sedentary")
+t_p1_sleep <- predict_fit_and_ci(m6, md, comp_labels = comp_labels, part_1 = "sleep")
+
+test_that("order of ilr parts doesn't matter for global compositional predictions", {
+  expect_equal(t_p1_sed$fit,t_p1_sleep $fit)
+})
+
+test_that("order of ilr parts doesn't matter - CI ", {
+  expect_equal(as.vector(t_p1_sed$lower_CI), as.vector(t_p1_sleep$lower_CI))
+})
+
+test_that("order of ilr parts doesn't matter - CI ", {
+  expect_equal(as.vector(t_p1_sed$upper_CI), as.vector(t_p1_sleep$upper_CI))
+})


### PR DESCRIPTION
Tests showing: 
- expected properties of CoDA models (order of variables when specifying pivot coordinates doesn't affect predictions)
- same results as deltacomp package with proportional reallocations